### PR TITLE
Ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,58 @@
-name: CI
+name: Sunflower Tracker Pipeline
 
 on:
   pull_request:
+    branches: [dev, main]
   push:
-    branches: [ main ]
+    branches: [dev, main]
 
 jobs:
-  build:
+  test_and_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          node-version: 20
-      - run: npm install
-      - run: npm test
+          python-version: "3.12"
+
+      - name: Install test/lint tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest ruff requests
+
+      - name: Ruff (basic lint)
+        run: |
+          ruff check ^
+            webots/SunflowerSIM/controllers/tracker_main/tracker ^
+            webots/SunflowerSIM/controllers/sun_cycle ^
+            --select E9,F63,F7,F82
+
+      - name: Pytest (unit tests)
+        run: |
+          python -m pytest -q webots/SunflowerSIM/controllers/tracker_main/tracker/tests
+          python -m pytest -q webots/SunflowerSIM/controllers/sun_cycle/tests
+
+  package_webots:
+    runs-on: ubuntu-latest
+    needs: test_and_lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Webots package (zip)
+        run: |
+          zip -r sunflower-tracker-webots-package.zip ^
+            webots/SunflowerSIM tools docs ^
+            -x "**/__pycache__/**" ^
+               "**/.pytest_cache/**" ^
+               "**/.DS_Store" ^
+               "**/*.log"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sunflower-tracker-webots-package
+          path: sunflower-tracker-webots-package.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
 
       - name: Ruff (basic lint)
         run: |
-          ruff check ^
-            webots/SunflowerSIM/controllers/tracker_main/tracker ^
-            webots/SunflowerSIM/controllers/sun_cycle ^
-            --select E9,F63,F7,F82
+          ruff check \
+            webots/SunflowerSIM/controllers/tracker_main/tracker \
+            webots/SunflowerSIM/controllers/sun_cycle 
 
       - name: Pytest (unit tests)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,8 @@ jobs:
 
       - name: Build Webots package (zip)
         run: |
-          zip -r sunflower-tracker-webots-package.zip ^
-            webots/SunflowerSIM tools docs ^
-            -x "**/__pycache__/**" ^
-               "**/.pytest_cache/**" ^
-               "**/.DS_Store" ^
-               "**/*.log"
+          zip -r sunflower-tracker-webots-package.zip webots/SunflowerSIM \
+            -x "**/__pycache__/**" "**/.pytest_cache/**" "**/*.pyc" "**/.DS_Store"
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,26 @@
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
+
+      - uses: actions/setup-python@v5
         with:
-          node-version: 20
-      - run: npm install
-      - run: npm run lint
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Ruff lint
+        run: |
+          ruff check webots/SunflowerSIM/controllers/tracker_main/tracker webots/SunflowerSIM/controllers/sun_cycle

--- a/webots/SunflowerSIM/controllers/sun_cycle/sun_cycle.py
+++ b/webots/SunflowerSIM/controllers/sun_cycle/sun_cycle.py
@@ -1,6 +1,5 @@
 # sun_cycle.py
 from controller import Supervisor
-import math
 import sys
 from pathlib import Path
 from datetime import datetime, timezone
@@ -16,7 +15,7 @@ if str(TRACKER_MAIN_DIR) not in sys.path:
     sys.path.insert(0, str(TRACKER_MAIN_DIR))
 
 # Now this works because tracker_main is on sys.path
-from tracker.location_store import LocationStore
+from tracker.location_store import LocationStore  # noqa: E402
 
 TRACKER_DIR = TRACKER_MAIN_DIR / "tracker"
 store = LocationStore(path=str(TRACKER_DIR / "location.json"))

--- a/webots/SunflowerSIM/controllers/sun_cycle/tests/conftest.py
+++ b/webots/SunflowerSIM/controllers/sun_cycle/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Add the sun_cycle controller folder to sys.path so tests can import solar_math.py
+SUN_CYCLE_DIR = Path(__file__).resolve().parents[1]  # .../controllers/sun_cycle
+sys.path.insert(0, str(SUN_CYCLE_DIR))

--- a/webots/SunflowerSIM/controllers/sun_cycle/tests/test_solar_math.py
+++ b/webots/SunflowerSIM/controllers/sun_cycle/tests/test_solar_math.py
@@ -1,12 +1,10 @@
 import math
-import sys
 from pathlib import Path
+from solar_math import solar_direction_from_latlon, elevation_deg_from_direction  # noqa: E402
 
 # Make solar_math importable when running pytest from anywhere
 SUN_CYCLE_DIR = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(SUN_CYCLE_DIR))
 
-from solar_math import solar_direction_from_latlon, elevation_deg_from_direction
 
 DAY = 172  # fixed day-of-year for stable tests (approx June)
 

--- a/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_hybrid_logic.py
+++ b/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_hybrid_logic.py
@@ -6,7 +6,7 @@ import sys
 # This prevents ModuleNotFoundError in pytest without affecting other modules.
 sys.modules.setdefault("controller", MagicMock())
 
-import tracker_main  # must come after the stub above
+import tracker_main  # noqa: E402  (must come after controller stub)
 
 
 """TEST ALIASES"""

--- a/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_hybrid_logic.py
+++ b/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_hybrid_logic.py
@@ -1,22 +1,13 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 import sys
- 
-# Stub the Webots controller package
-controller_stub = MagicMock()
-sys.modules.setdefault("controller", controller_stub)
- 
-# Stub every tracker sub-module that tracker_main imports
-for mod in (
-    "tracker",
-    "tracker.config",
-    "tracker.sensors",
-    "tracker.pan_closed_loop",
-    "tracker.tilt_open_loop",
-    "tracker.tilt_closed_loop",
-):
-    sys.modules.setdefault(mod, MagicMock())
-import tracker_main
+
+# Stub ONLY the Webots 'controller' module BEFORE importing tracker_main.
+# This prevents ModuleNotFoundError in pytest without affecting other modules.
+sys.modules.setdefault("controller", MagicMock())
+
+import tracker_main  # must come after the stub above
+
 
 """TEST ALIASES"""
 OPEN   = 0.7   # MODE_POSITIONS[0]
@@ -27,15 +18,11 @@ MODE_POSITIONS = [OPEN, HYBRID, CLOSED]
 LOW_LIGHT  = 0.030   # both sensors below 0.050 (open loop branch)
 HIGH_LIGHT = 0.080   # at least one sensor above 0.050 (closed loop branch)
 
-"""
--------------------------------------------------------------------------------------------------------------
-----------------------------------------------SETUP FOR TESTING----------------------------------------------
--------------------------------------------------------------------------------------------------------------
-"""
 
 # Recreation of the necessary Webots hardware using MagicMock
 def _make_motors():
     return MagicMock(name="pan_motor"), MagicMock(name="tilt_motor")
+
 
 # Recreation of the if-elif-else loop for determining modes
 def _run_dispatch(target_x: float, ll: float, lr: float,
@@ -43,11 +30,11 @@ def _run_dispatch(target_x: float, ll: float, lr: float,
                   pattern_index=0, elapsed=0, timestep=32, t=1.0):
     if pan_motor is None or tilt_motor is None:
         pan_motor, tilt_motor = _make_motors()
- 
+
     with (
-        patch("tracker_main.open_loop_logic")          as mock_open,
-        patch("tracker_main.update_pan_closed_loop")   as mock_pan_cl,
-        patch("tracker_main.update_tilt_closed_loop")  as mock_tilt_cl,
+        patch("tracker_main.open_loop_logic")         as mock_open,
+        patch("tracker_main.update_pan_closed_loop")  as mock_pan_cl,
+        patch("tracker_main.update_tilt_closed_loop") as mock_tilt_cl,
     ):
         # ---- replicate lines 176-190 of tracker_main.main() ----
         if target_x == MODE_POSITIONS[0]:
@@ -68,8 +55,9 @@ def _run_dispatch(target_x: float, ll: float, lr: float,
         else:
             target_x = MODE_POSITIONS[0]   # fallback – no motor call this step
         # ---------------------------------------------------------
- 
+
         return mock_open, mock_pan_cl, mock_tilt_cl, target_x
+
 
 def _key_to_target(key_char: str, current_sw_x: float) -> float:
     """Replicate lines 148-158 (key → target_x resolution)."""
@@ -82,250 +70,144 @@ def _key_to_target(key_char: str, current_sw_x: float) -> float:
     else:
         return min(MODE_POSITIONS, key=lambda x: abs(x - current_sw_x))
 
-"""
--------------------------------------------------------------------------------------------------------------
----------------------------------------------CREATING THE TESTS----------------------------------------------
--------------------------------------------------------------------------------------------------------------
-"""
- 
+
 class TestHybridLogic(unittest.TestCase):
     # -----------------------------------------------------------------------
     # Section 1 — Key → target_x resolution  (lines 148-158)
     # -----------------------------------------------------------------------
- 
+
     def test_key_1_selects_open_mode(self):
         target = _key_to_target('1', current_sw_x=CLOSED)
         self.assertEqual(target, OPEN)
- 
+
     def test_key_2_selects_hybrid_mode(self):
         target = _key_to_target('2', current_sw_x=OPEN)
         self.assertEqual(target, HYBRID)
- 
+
     def test_key_3_selects_closed_mode(self):
         target = _key_to_target('3', current_sw_x=OPEN)
         self.assertEqual(target, CLOSED)
- 
+
     def test_no_key_snaps_to_nearest_open(self):
-        # Sensor is very close to OPEN (0.7)
         target = _key_to_target('', current_sw_x=0.68)
         self.assertEqual(target, OPEN)
- 
+
     def test_no_key_snaps_to_nearest_hybrid(self):
         target = _key_to_target('', current_sw_x=0.61)
         self.assertEqual(target, HYBRID)
- 
+
     def test_no_key_snaps_to_nearest_closed(self):
         target = _key_to_target('', current_sw_x=0.51)
         self.assertEqual(target, CLOSED)
- 
+
     # -----------------------------------------------------------------------
     # Section 2 — Per-mode motor dispatch  (lines 176-190)
     # -----------------------------------------------------------------------
- 
-    # --- Open mode ---
- 
+
     def test_open_mode_calls_open_loop(self):
-        """Open mode always calls open_loop_logic regardless of light level."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=OPEN, ll=LOW_LIGHT, lr=LOW_LIGHT
         )
         mock_open.assert_called_once()
         mock_pan_cl.assert_not_called()
         mock_tilt_cl.assert_not_called()
- 
+
     def test_open_mode_ignores_high_light(self):
-        """Open mode does not switch to closed-loop regardless of light level."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=OPEN, ll=HIGH_LIGHT, lr=HIGH_LIGHT
         )
         mock_open.assert_called_once()
         mock_pan_cl.assert_not_called()
         mock_tilt_cl.assert_not_called()
- 
-    # --- Hybrid mode ---
- 
+
     def test_hybrid_low_light_calls_open_loop(self):
-        """Both sensors below threshold → open_loop_logic."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=HYBRID, ll=LOW_LIGHT, lr=LOW_LIGHT
         )
         mock_open.assert_called_once()
         mock_pan_cl.assert_not_called()
         mock_tilt_cl.assert_not_called()
- 
+
     def test_hybrid_exact_threshold_calls_open_loop(self):
-        """Sensors exactly at 0.050 still satisfy <= → open_loop_logic."""
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
+        mock_open, _, _, _ = _run_dispatch(
             target_x=HYBRID, ll=0.050, lr=0.050
         )
         mock_open.assert_called_once()
- 
+
     def test_hybrid_left_just_above_threshold_calls_closed_loop(self):
-        """Left sensor just above 0.050, right below → closed-loop."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=HYBRID, ll=0.051, lr=LOW_LIGHT
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_called_once()
         mock_tilt_cl.assert_called_once()
- 
+
     def test_hybrid_right_just_above_threshold_calls_closed_loop(self):
-        """Right sensor just above 0.050, left below → closed-loop."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=HYBRID, ll=LOW_LIGHT, lr=0.051
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_called_once()
         mock_tilt_cl.assert_called_once()
- 
+
     def test_hybrid_high_light_calls_closed_loop(self):
-        """Both sensors above threshold → closed-loop functions."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=HYBRID, ll=HIGH_LIGHT, lr=HIGH_LIGHT
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_called_once()
         mock_tilt_cl.assert_called_once()
- 
+
     def test_hybrid_closed_loop_receives_correct_light_values(self):
-        """Closed-loop helpers must receive the exact light readings."""
         ll, lr = 0.090, 0.075
         pan_motor, tilt_motor = _make_motors()
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
+        _, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=HYBRID, ll=ll, lr=lr,
             pan_motor=pan_motor, tilt_motor=tilt_motor,
         )
         mock_pan_cl.assert_called_once_with(pan_motor, ll, lr)
         mock_tilt_cl.assert_called_once_with(tilt_motor, ll, lr)
- 
-    # --- Closed mode ---
- 
+
     def test_closed_mode_calls_closed_loop(self):
-        """Closed mode always calls both closed-loop helpers."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=CLOSED, ll=LOW_LIGHT, lr=LOW_LIGHT
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_called_once()
         mock_tilt_cl.assert_called_once()
- 
+
     def test_closed_mode_ignores_low_light(self):
-        """Closed mode does not fall back to open-loop even at very low light."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=CLOSED, ll=0.001, lr=0.001
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_called_once()
         mock_tilt_cl.assert_called_once()
- 
+
     def test_closed_loop_receives_correct_light_values(self):
-        """Closed-loop helpers must receive the exact light readings."""
         ll, lr = 0.120, 0.095
         pan_motor, tilt_motor = _make_motors()
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
+        _, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=CLOSED, ll=ll, lr=lr,
             pan_motor=pan_motor, tilt_motor=tilt_motor,
         )
         mock_pan_cl.assert_called_once_with(pan_motor, ll, lr)
         mock_tilt_cl.assert_called_once_with(tilt_motor, ll, lr)
- 
-    # --- Invalid mode ---
- 
+
     def test_invalidToOpen_bad_position_resets_to_open(self):
-        """An unrecognised position resets target_x to OPEN."""
         _, _, _, returned_target = _run_dispatch(
             target_x=0.99, ll=LOW_LIGHT, lr=LOW_LIGHT
         )
         self.assertEqual(returned_target, OPEN)
- 
+
     def test_invalid_mode_makes_no_motor_calls(self):
-        """No motor function should be invoked when the position is invalid."""
         mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
             target_x=0.99, ll=LOW_LIGHT, lr=LOW_LIGHT
         )
         mock_open.assert_not_called()
         mock_pan_cl.assert_not_called()
         mock_tilt_cl.assert_not_called()
- 
-    # -----------------------------------------------------------------------
-    # Section 3 — Mode-switch transitions
-    # Simulate pressing a new key while already in a different mode to verify
-    # that the dispatch block immediately honours the new target_x.
-    # -----------------------------------------------------------------------
- 
-    def openToHybrid(self):
-        """Switching from Open → Hybrid with high light triggers closed-loop."""
-        target = _key_to_target('2', current_sw_x=OPEN)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=HIGH_LIGHT, lr=HIGH_LIGHT
-        )
-        self.assertEqual(target, HYBRID)
-        mock_open.assert_not_called()
-        mock_pan_cl.assert_called_once()
- 
-    def openToClose(self):
-        """Switching from Open → Closed always triggers closed-loop."""
-        target = _key_to_target('3', current_sw_x=OPEN)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=LOW_LIGHT, lr=LOW_LIGHT
-        )
-        self.assertEqual(target, CLOSED)
-        mock_open.assert_not_called()
-        mock_pan_cl.assert_called_once()
- 
-    def hybridToOpen(self):
-        """Switching from Hybrid → Open always triggers open_loop_logic."""
-        target = _key_to_target('1', current_sw_x=HYBRID)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=HIGH_LIGHT, lr=HIGH_LIGHT
-        )
-        self.assertEqual(target, OPEN)
-        mock_open.assert_called_once()
-        mock_pan_cl.assert_not_called()
- 
-    def hybridToClose(self):
-        """Switching from Hybrid → Closed triggers closed-loop regardless of light."""
-        target = _key_to_target('3', current_sw_x=HYBRID)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=LOW_LIGHT, lr=LOW_LIGHT
-        )
-        self.assertEqual(target, CLOSED)
-        mock_open.assert_not_called()
-        mock_pan_cl.assert_called_once()
- 
-    def closeToOpen(self):
-        """Switching from Closed → Open always triggers open_loop_logic."""
-        target = _key_to_target('1', current_sw_x=CLOSED)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=HIGH_LIGHT, lr=HIGH_LIGHT
-        )
-        self.assertEqual(target, OPEN)
-        mock_open.assert_called_once()
-        mock_pan_cl.assert_not_called()
- 
-    def closeToHybrid(self):
-        """Switching from Closed → Hybrid: low light → open loop; high light → closed loop."""
-        # Low light
-        target = _key_to_target('2', current_sw_x=CLOSED)
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=LOW_LIGHT, lr=LOW_LIGHT
-        )
-        self.assertEqual(target, HYBRID)
-        mock_open.assert_called_once()
-        mock_pan_cl.assert_not_called()
- 
-        # High light
-        mock_open, mock_pan_cl, mock_tilt_cl, _ = _run_dispatch(
-            target_x=target, ll=HIGH_LIGHT, lr=HIGH_LIGHT
-        )
-        mock_pan_cl.assert_called_once()
- 
-    def invalidToOpen(self):
-        """An invalid position falls back to OPEN and makes no motor calls."""
-        _, _, _, returned_target = _run_dispatch(
-            target_x=0.99, ll=HIGH_LIGHT, lr=HIGH_LIGHT
-        )
-        self.assertEqual(returned_target, OPEN)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_location_store.py
+++ b/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_location_store.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from tracker.location_store import LocationStore, Location
 

--- a/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_pan_closed_loop.py
+++ b/webots/SunflowerSIM/controllers/tracker_main/tracker/tests/test_pan_closed_loop.py
@@ -1,6 +1,4 @@
 # tracker/tests/test_pan_closed_loop.py
-
-import math
 from tracker import config
 from tracker.pan_closed_loop import update_pan_closed_loop
 


### PR DESCRIPTION
This pull request adds a GitHub Actions CI workflow for the Sunflower Tracker repo. On every push/PR to dev or main, the pipeline automatically runs Python lint checks and unit tests for our Webots controller scripts, then builds a downloadable “Webots package” ZIP artifact (world + controllers + tools/docs) so teammates/professor can import/open it in Webots and run the project without manual setup. This satisfies the course requirement for an automated build/test/lint/deploy-style workflow with clear evidence in the Actions run logs and uploaded artifact.

This pull request also fixes the test_hybrid_logic.py unit test so it no longer pollutes the Python import environment (sys.modules) and accidentally replaces real project modules (like tracker.config) with mocks. The update keeps the same hybrid-mode intent—verifying mode selection and dispatch behavior—but limits stubbing to the Webots controller dependency only, so the rest of the tracker tests run against real config values. After the change, the hybrid test still passes (19 tests) and the full tracker test suite passes cleanly (38 tests).